### PR TITLE
use map instead of filter to skip using sort

### DIFF
--- a/example/src/CustomReactions.tsx
+++ b/example/src/CustomReactions.tsx
@@ -14,7 +14,6 @@ export default function CustomReactions() {
   ]);
 
   const selected = emojis
-    .sort((a, b) => (a.emoji < b.emoji ? 1 : -1))
     .map((emoji, i) => (
       <EmojiCounter
         key={i}

--- a/example/src/CustomReactionsV2.tsx
+++ b/example/src/CustomReactionsV2.tsx
@@ -12,7 +12,6 @@ export default function CustomReactions() {
   const [emojis, increment] = useEmojis(DEFAULT_EMOJI_OPTIONS);
 
   const selected = emojis
-    .sort((a, b) => (a.emoji < b.emoji ? 1 : -1))
     .map((emoji, i) => (
       <EmojiCounter
         key={i}

--- a/src/EmojiBlock.tsx
+++ b/src/EmojiBlock.tsx
@@ -22,7 +22,6 @@ export default function EmojiBlock({
   }, [state]);
 
   const mappedReactions = state
-    .sort((a, b) => (a.emoji < b.emoji ? 1 : -1))
     .map((emoji, i) => (
       <EmojiCounter
         key={i}

--- a/src/EmojiBlock.tsx
+++ b/src/EmojiBlock.tsx
@@ -21,15 +21,14 @@ export default function EmojiBlock({
     }
   }, [state]);
 
-  const mappedReactions = state
-    .map((emoji, i) => (
-      <EmojiCounter
-        key={i}
-        emoji={emoji}
-        initialValue={emoji.counter}
-        onClick={increment}
-      />
-    ));
+  const mappedReactions = state.map((emoji, i) => (
+    <EmojiCounter
+      key={i}
+      emoji={emoji}
+      initialValue={emoji.counter}
+      onClick={increment}
+    />
+  ));
 
   return (
     <div className='reaction-block' data-testid='reaction-block'>

--- a/src/__test__/useEmojis.test.tsx
+++ b/src/__test__/useEmojis.test.tsx
@@ -1,6 +1,9 @@
 import { useEmojis } from '../index';
 import { act, renderHook } from '@testing-library/react-hooks';
 
+/**
+ * We can't destructure the reducer, so we have to use it's indexes instead.
+ */
 describe('useEmojis', () => {
   it('should return empty state with no initial values', () => {
     const { result } = renderHook(() => useEmojis());
@@ -25,6 +28,17 @@ describe('useEmojis', () => {
       result.current[1]({ emoji: '🐼', label: 'panda' });
     });
     expect(result.current[0][0].counter).toBe(1);
+  });
+
+  it('should not break if counter starts below 0', () => {
+    const { result } = renderHook(() =>
+      useEmojis([{ emoji: '🐈', label: 'cat', counter: -10 }]),
+    );
+    const [emojis, incr, decr] = result.current;
+    act(() => {
+      incr({ emoji: '🐈', label: 'cat' });
+    });
+    expect(emojis[0].counter).toBe(0);
   });
 
   it('should increment counter', () => {

--- a/src/__test__/useEmojis.test.tsx
+++ b/src/__test__/useEmojis.test.tsx
@@ -34,11 +34,25 @@ describe('useEmojis', () => {
     const { result } = renderHook(() =>
       useEmojis([{ emoji: '🐈', label: 'cat', counter: -10 }]),
     );
-    const [emojis, incr] = result.current;
+    const [, incr] = result.current;
     act(() => {
       incr({ emoji: '🐈', label: 'cat' });
     });
-    expect(emojis[0].counter).toBe(0);
+    expect(result.current[0].length).toBe(0);
+  });
+
+  it('should display emoji if counter goes over 0', () => {
+    const { result } = renderHook(() =>
+      useEmojis([{ emoji: '🐈', label: 'cat', counter: -3 }]),
+    );
+    const [, incr] = result.current;
+    act(() => {
+      incr({ emoji: '🐈', label: 'cat' });
+      incr({ emoji: '🐈', label: 'cat' });
+      incr({ emoji: '🐈', label: 'cat' });
+      incr({ emoji: '🐈', label: 'cat' });
+    });
+    expect(result.current[0].length).toBe(1);
   });
 
   it('should increment counter', () => {

--- a/src/__test__/useEmojis.test.tsx
+++ b/src/__test__/useEmojis.test.tsx
@@ -34,7 +34,7 @@ describe('useEmojis', () => {
     const { result } = renderHook(() =>
       useEmojis([{ emoji: '🐈', label: 'cat', counter: -10 }]),
     );
-    const [emojis, incr, decr] = result.current;
+    const [emojis, incr] = result.current;
     act(() => {
       incr({ emoji: '🐈', label: 'cat' });
     });
@@ -80,5 +80,18 @@ describe('useEmojis', () => {
       result.current[1]({ emoji: '🐼', label: 'panda' });
     });
     expect(result.current[0][0].counter).toBe(1);
+  });
+
+  it('should filter correctly emojis if they were already in state', () => {
+    const { result } = renderHook(() =>
+      useEmojis([{ emoji: '🐼', label: 'panda', counter: 4 }]),
+    );
+    const [emojis, incr, decr] = result.current;
+    act(() => {
+      incr({ emoji: '🐶', label: 'dog' });
+      decr({ emoji: '🐼', label: 'panda' });
+    });
+    expect(emojis[0].counter).toBe(3);
+    expect(emojis[1].counter).toBe(1);
   });
 });

--- a/src/lib/useEmojis.ts
+++ b/src/lib/useEmojis.ts
@@ -22,7 +22,7 @@ function reducer(state: EmojiiState, action: EmojiAction) {
   return state
     .map((rea) => {
       if (rea.emoji === emojiFromState.emoji) {
-        return emojiFromState.counter! > 0 ? null : emojiFromState;
+        return emojiFromState.counter! === 0 ? null : emojiFromState;
       }
       return rea;
     })

--- a/src/lib/useEmojis.ts
+++ b/src/lib/useEmojis.ts
@@ -9,7 +9,8 @@ import type {
 
 function reducer(state: EmojiiState, action: EmojiAction) {
   const { emoji } = action;
-  const emojiFromState = state.find((em) => em.emoji === emoji.emoji) || emoji;
+  const stateEmoji = state.find((em) => em.emoji === emoji.emoji);
+  const emojiFromState = stateEmoji || emoji;
   emojiFromState.counter = emojiFromState.counter || 0;
   switch (action.type) {
     case 'i':
@@ -19,14 +20,17 @@ function reducer(state: EmojiiState, action: EmojiAction) {
       emojiFromState.counter--;
       if (emojiFromState.counter <= 0) emojiFromState.counter = 0;
   }
-  return state
-    .map((rea) => {
-      if (rea.emoji === emojiFromState.emoji) {
-        return emojiFromState.counter! === 0 ? null : emojiFromState;
-      }
-      return rea;
-    })
-    .filter((e) => e !== null) as IEmoji[];
+  if (stateEmoji) {
+    return state
+      .map((rea) => {
+        if (rea.emoji === emojiFromState.emoji) {
+          return emojiFromState.counter === 0 ? null : emojiFromState;
+        }
+        return rea;
+      })
+      .filter((e) => e !== null) as IEmoji[];
+  }
+  return [...state, emojiFromState];
 }
 
 export default function useEmojis(initialEmojis: IEmoji[] = []): UseEmoji {

--- a/src/lib/useEmojis.ts
+++ b/src/lib/useEmojis.ts
@@ -26,12 +26,9 @@ function reducer(state: EmojiiState, action: EmojiAction) {
 
   return state
     .map((rea) => {
-      if (rea.emoji === emojiFromState.emoji) {
-        return emojiFromState.counter === 0 ? null : emojiFromState;
-      }
-      return rea;
+      return rea.emoji === emojiFromState.emoji ? emojiFromState : rea;
     })
-    .filter((e) => e !== null) as IEmoji[];
+    .filter((emoji) => emoji.counter !== 0) as IEmoji[];
 }
 
 export default function useEmojis(initialEmojis: IEmoji[] = []): UseEmoji {

--- a/src/lib/useEmojis.ts
+++ b/src/lib/useEmojis.ts
@@ -18,8 +18,9 @@ function reducer(state: EmojiiState, action: EmojiAction) {
       break;
     case 'd':
       emojiFromState.counter--;
-      if (emojiFromState.counter <= 0) emojiFromState.counter = 0;
   }
+  if (emojiFromState.counter <= 0) emojiFromState.counter = 0;
+
   if (!stateEmoji) {
     state.push(emojiFromState);
   }

--- a/src/lib/useEmojis.ts
+++ b/src/lib/useEmojis.ts
@@ -3,6 +3,7 @@ import type {
   EmojiAction,
   EmojiFN,
   EmojiiState,
+  FullIEmoji,
   IEmoji,
   UseEmoji,
 } from '../types';
@@ -29,14 +30,15 @@ function reducer(state: EmojiiState, action: EmojiAction) {
     .map((rea) => {
       return rea.emoji === emojiFromState.emoji ? emojiFromState : rea;
     })
-    .filter((emoji) => emoji.counter !== 0) as IEmoji[];
+    .filter((emoji) => emoji.counter !== 0) as FullIEmoji[];
 }
 
 export default function useEmojis(initialEmojis: IEmoji[] = []): UseEmoji {
-  const [emojis, dispatch] = useReducer(reducer, [...initialEmojis]);
-
+  const [emojis, dispatch] = useReducer(reducer, [
+    ...initialEmojis,
+    /* Forces correct typing of state, but still accepts inital state without counter. */
+  ] as FullIEmoji[]);
   const increment: EmojiFN = (emoji) => dispatch({ type: 'i', emoji: emoji });
   const decrement: EmojiFN = (emoji) => dispatch({ type: 'd', emoji: emoji });
-
   return [emojis, increment, decrement];
 }

--- a/src/lib/useEmojis.ts
+++ b/src/lib/useEmojis.ts
@@ -17,12 +17,16 @@ function reducer(state: EmojiiState, action: EmojiAction) {
       break;
     case 'd':
       emojiFromState.counter--;
-      if (emojiFromState.counter < 0) emojiFromState.counter = 0;
+      if (emojiFromState.counter <= 0) emojiFromState.counter = 0;
   }
-  return [
-    ...state.filter((rea) => rea.emoji !== emojiFromState.emoji),
-    ...(emojiFromState.counter > 0 ? [emojiFromState] : []),
-  ];
+  return state
+    .map((rea) => {
+      if (rea.emoji === emojiFromState.emoji) {
+        return emojiFromState.counter! > 0 ? null : emojiFromState;
+      }
+      return rea;
+    })
+    .filter((e) => e !== null) as IEmoji[];
 }
 
 export default function useEmojis(initialEmojis: IEmoji[] = []): UseEmoji {

--- a/src/lib/useEmojis.ts
+++ b/src/lib/useEmojis.ts
@@ -20,7 +20,6 @@ function reducer(state: EmojiiState, action: EmojiAction) {
     case 'd':
       emojiFromState.counter--;
   }
-  if (emojiFromState.counter <= 0) emojiFromState.counter = 0;
 
   if (!stateEmoji) {
     state.push(emojiFromState);
@@ -28,9 +27,11 @@ function reducer(state: EmojiiState, action: EmojiAction) {
 
   return state
     .map((rea) => {
-      return rea.emoji === emojiFromState.emoji ? emojiFromState : rea;
+      return (rea.emoji === emojiFromState.emoji
+        ? emojiFromState
+        : rea) as FullIEmoji;
     })
-    .filter((emoji) => emoji.counter !== 0) as FullIEmoji[];
+    .filter((emoji) => emoji.counter > 0) as FullIEmoji[];
 }
 
 export default function useEmojis(initialEmojis: IEmoji[] = []): UseEmoji {

--- a/src/lib/useEmojis.ts
+++ b/src/lib/useEmojis.ts
@@ -20,17 +20,18 @@ function reducer(state: EmojiiState, action: EmojiAction) {
       emojiFromState.counter--;
       if (emojiFromState.counter <= 0) emojiFromState.counter = 0;
   }
-  if (stateEmoji) {
-    return state
-      .map((rea) => {
-        if (rea.emoji === emojiFromState.emoji) {
-          return emojiFromState.counter === 0 ? null : emojiFromState;
-        }
-        return rea;
-      })
-      .filter((e) => e !== null) as IEmoji[];
+  if (!stateEmoji) {
+    state.push(emojiFromState);
   }
-  return [...state, emojiFromState];
+
+  return state
+    .map((rea) => {
+      if (rea.emoji === emojiFromState.emoji) {
+        return emojiFromState.counter === 0 ? null : emojiFromState;
+      }
+      return rea;
+    })
+    .filter((e) => e !== null) as IEmoji[];
 }
 
 export default function useEmojis(initialEmojis: IEmoji[] = []): UseEmoji {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ export interface IEmoji {
   label?: string;
   counter?: number;
 }
-
+export type FullIEmoji = Required<Pick<IEmoji, 'counter'>> & IEmoji;
 export type EmojiFN = (emoji: IEmoji) => void;
 
 export type UseEmoji = [IEmoji[], EmojiFN, EmojiFN];


### PR DESCRIPTION
This is just an idea, instead of using filter and always putting the object at the end:
```js
return state
    .map((rea) => {
      if (rea.emoji === emojiFromState.emoji) {
        return emojiFromState.counter! === 0 ? null : emojiFromState;
      }
      return rea;
    })
    .filter((e) => e !== null) as IEmoji[];
```

map the object and return same order.

